### PR TITLE
feat: filter non-degree courses from transcript parsing

### DIFF
--- a/packages/schedule/src/transcriptParser.ts
+++ b/packages/schedule/src/transcriptParser.ts
@@ -1,4 +1,4 @@
-import { normalizeCourseCode } from "./utils/courseUtils";
+import { normalizeCourseCode, isNonDegreeCourse } from "./utils/courseUtils";
 
 /** Course code pattern: 3–4 letters + 4–5 digits, optional letter suffix (e.g. ADM 1100, ESL 2121) */
 const COURSE_CODE_REGEX = /\b([A-Z]{3,4})\s*(\d{4,5}[A-Z]?)\b/gi;
@@ -221,8 +221,11 @@ export async function parseTranscriptPdf(
   }
 
   const fullText = textParts.join("\n");
+  // Filter out non-degree courses (ITD ethics courses don't count toward degree requirements)
+  const filteredCourses = [...allCodes].filter(code => !isNonDegreeCourse(code));
+  
   return {
-    courses: [...allCodes],
+    courses: filteredCourses,
     fullText,
     startingYear: parseStartingYear(fullText),
   };

--- a/packages/schedule/src/utils/courseUtils.ts
+++ b/packages/schedule/src/utils/courseUtils.ts
@@ -86,6 +86,19 @@ export function isOptCourse(code: string): boolean {
 }
 
 /**
+ * Check if a course is a non-degree mandatory course (e.g., ethics).
+ * These courses are required for all uOttawa students but don't count 
+ * towards degree requirements and are not in the catalogue.
+ * Currently includes:
+ * - ITD 1100: Ethics in Engineering
+ * - ITD 1500: Design and Ethics
+ */
+export function isNonDegreeCourse(code: string): boolean {
+  const normalized = normalizeCourseCode(code);
+  return normalized === 'ITD 1100' || normalized === 'ITD 1500';
+}
+
+/**
  * Format a course code with its title for display.
  * e.g., "CSI 2101" + "Discrete Structures" -> "CSI 2101 - Discrete Structures"
  */


### PR DESCRIPTION
Currently courses such as ITD1100 and ITD1500 are not recognized by the parser; this is an issue because all students are required to take one of these ethics courses that do not contribute to their degree. This PR solves this by filtering out these course codes when they are parsed