### PR TITLE
feat(native): expo-dev-client + EAS dev profile, native build CI smoke, refresh docs

### DIFF
--- a/.github/workflows/native-build-check.yml
+++ b/.github/workflows/native-build-check.yml
@@ -1,0 +1,173 @@
+name: Native Build Check
+
+# Compile-only smoke for the Expo app in `apps/native`. The existing `native`
+# job in ci.yml runs the TS typecheck + jest-expo render tests under Node, but it
+# never compiles the actual native projects — so a broken config plugin, a Gradle
+# change, or a JNI/xcframework regression in the Rust engine would only surface at
+# release time (Native Deploy). This workflow catches that earlier by doing a
+# no-signing debug build of both platforms on every native-affecting PR.
+#
+# It deliberately uses NO store credentials: Android builds a debug APK (auto
+# debug keystore) and iOS builds for the simulator with code signing disabled, so
+# it needs neither EXPO_TOKEN nor Apple/Play credentials. Release builds + store
+# submission stay in .github/workflows/native-deploy.yml (eas build --local).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/native/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/native-build-check.yml"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - "apps/native/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/native-build-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-build-check-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    name: Android debug compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install Android NDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Matches the NDK the React Native Gradle plugin (Expo SDK) pins and that
+          # cargo-ndk uses to cross-compile the JNI engine .so.
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "ndk;27.1.12297006"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.1.12297006" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/27.1.12297006" >> "$GITHUB_ENV"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/engine/target
+          key: cargo-native-android-${{ hashFiles('packages/engine/Cargo.lock') }}
+          restore-keys: cargo-native-android-
+
+      - name: Install cargo-ndk
+        shell: bash
+        run: cargo ndk --version >/dev/null 2>&1 || cargo install cargo-ndk --locked
+
+      - name: Install protoc
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      - name: Generate proto + bundled data
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm generate
+          pnpm --filter native prebuild:data
+
+      - name: Build JNI engine (libuoplan_engine.so per ABI)
+        run: pnpm build:engine-native-ffi-android
+
+      - name: Prebuild Android project (CNG)
+        run: pnpm --filter native exec expo prebuild --platform android --no-install
+
+      - name: Compile debug APK (no signing)
+        working-directory: apps/native/android
+        run: ./gradlew :app:assembleDebug --no-daemon
+
+  ios:
+    name: iOS simulator compile
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/engine/target
+          key: cargo-native-ios-${{ hashFiles('packages/engine/Cargo.lock') }}
+          restore-keys: cargo-native-ios-
+
+      - name: Install protoc
+        shell: bash
+        run: brew list protobuf >/dev/null 2>&1 || brew install protobuf
+
+      - name: Generate proto + bundled data
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm generate
+          pnpm --filter native prebuild:data
+
+      - name: Build engine XCFramework
+        run: pnpm build:engine-native-ffi
+
+      - name: Prebuild iOS project (CNG)
+        run: pnpm --filter native exec expo prebuild --platform ios --no-install
+
+      - name: Pod install
+        working-directory: apps/native/ios
+        run: pod install
+
+      - name: Compile for simulator (no signing)
+        working-directory: apps/native/ios
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `expo prebuild` writes a lowercase `uoplan` scheme/workspace (the
+          # generated native identifiers track the lowercase expo.name).
+          xcodebuild build \
+            -workspace uoplan.xcworkspace \
+            -scheme uoplan \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO

--- a/apps/native/README.md
+++ b/apps/native/README.md
@@ -1,56 +1,98 @@
-# Welcome to your Expo app 👋
+# uoPlan native app
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+The uoPlan iOS + Android app — an [Expo](https://expo.dev) (SDK 56) / React Native
+client in the `uoplan.party` monorepo. It shares the schedule engine, requirements
+logic, data layer and UI primitives with the web app via the workspace packages.
 
-## Get started
+> **Not Expo Go.** The app links a custom native module (`modules/uoplan-engine` — the
+> Rust schedule engine, a JNI `libuoplan_engine.so` on Android and a
+> `UoplanEngine.xcframework` on iOS). Expo Go only bundles the stock Expo SDK modules,
+> so it **cannot** run this app. All development uses **development builds** (your own
+> debug build of the app, with `expo-dev-client`), never Expo Go.
 
-1. Install dependencies
+## Prerequisites
 
-   ```bash
-   npm install
-   ```
+- **pnpm** (the repo package manager) and Node 24.
+- **Rust** (stable) — the schedule engine compiles to a native lib per platform.
+- **iOS:** macOS + Xcode (+ CocoaPods, bundled with Xcode).
+- **Android:** Android Studio with the SDK + **NDK `27.1.12297006`**, and **JDK 17**
+  (Temurin / Homebrew `openjdk@17` — Android Studio's bundled JBR fails the Gradle
+  toolchain check).
 
-2. Start the app
-
-   ```bash
-   npx expo start
-   ```
-
-In the output, you'll find options to open the app in a
-
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
-
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
-
-## Get a fresh project
-
-When you're ready, run:
+## First-time setup
 
 ```bash
-npm run reset-project
+pnpm install                 # from the repo root
+pnpm generate                # proto TS + bundled .pb data (needed by typecheck/tests/build)
 ```
 
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
+The native Rust engine artifacts are git-ignored and must be built before a native
+compile (rebuild them whenever `packages/engine` changes):
 
-### Other setup steps
+```bash
+pnpm build:engine-native-ffi            # iOS  → modules/uoplan-engine/ios/UoplanEngine.xcframework
+ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.1.12297006 \
+  pnpm build:engine-native-ffi-android  # Android → per-ABI libuoplan_engine.so
+```
 
-- To set up ESLint for linting, run `npx expo lint`, or follow our guide on ["Using ESLint and Prettier"](https://docs.expo.dev/guides/using-eslint/)
-- If you'd like to set up unit testing, follow our guide on ["Unit Testing with Jest"](https://docs.expo.dev/develop/unit-testing/)
-- Learn more about the TypeScript setup in this template in our guide on ["Using TypeScript"](https://docs.expo.dev/guides/typescript/)
+## Run on a simulator / emulator (development build)
 
-## Learn more
+```bash
+pnpm --filter native start     # Metro dev server (port 8081)
+pnpm --filter native ios       # expo run:ios     — build + launch the dev client on the iOS simulator
+pnpm --filter native android   # expo run:android — build + launch the dev client on an Android emulator
+```
 
-To learn more about developing your project with Expo, look at the following resources:
+`expo run:*` runs `expo prebuild` (regenerating the git-ignored `ios/` + `android/`
+projects from `app.config.ts`) and then a native debug build. Edit JS/TS and it
+hot-reloads against Metro; you only rebuild when native config or dependencies change.
 
-- [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
-- [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
+> On iOS, build for the **simulator** (plain `pnpm --filter native ios`). Targeting a
+> _booted_ simulator with `expo run:ios --device <udid>` is misdetected as a physical
+> device and fails code signing — build via the simulator path instead.
 
-## Join the community
+## Build a release locally (EAS, no cloud minutes)
 
-Join our community of developers creating universal apps.
+Builds and signing are managed by EAS, but run entirely on your machine with
+`--local` — the same recipe CI uses, with zero EAS Build cloud minutes. EAS holds the
+signing credentials (iOS distribution cert + provisioning profile, Android keystore),
+so you only need to be logged in (`eas login`, or set `EXPO_TOKEN`).
 
-- [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+```bash
+# convenience wrapper (forces our pnpm-patched local build plugin):
+pnpm --filter native eas:build:local -- --profile production --platform ios
+pnpm --filter native eas:build:local -- --profile production --platform android
+
+# or call eas directly:
+eas build --local --profile development --platform android   # dev-client APK, no store creds
+eas build --local --profile preview     --platform ios       # internal/simulator build
+eas build --local --profile production  --platform ios       # signed store build (.ipa)
+```
+
+Build profiles live in [`eas.json`](./eas.json): `development` (dev client, internal),
+`preview` (internal apk / iOS simulator), `production` (store).
+
+## Submit to the stores
+
+```bash
+eas submit --profile production --platform ios      --path <build.ipa>   # → TestFlight
+eas submit --profile production --platform android  --path <build.aab>   # → Play internal track
+```
+
+The very first Android release must be uploaded to Play Console by hand before the Play
+API is authorized — see the runbook.
+
+## CI
+
+- **`.github/workflows/native-build-check.yml`** — PR/push smoke: no-signing debug
+  compile of both platforms (Android `assembleDebug` on Linux, iOS simulator build on
+  macOS). Catches native breakage before release; needs no credentials.
+- **`.github/workflows/native-deploy.yml`** — release: `eas build --local` on GitHub
+  runners + `eas submit`. Auto-triggered by release-please, or on-demand via
+  `workflow_dispatch`. Needs the `EXPO_TOKEN` secret.
+
+## More
+
+The full deployment runbook — credentials, store setup, the monorepo/native-engine
+build steps, and Android R8/ProGuard notes — is in
+[`docs/native-deploy.md`](../../docs/native-deploy.md).

--- a/apps/native/eas.json
+++ b/apps/native/eas.json
@@ -13,6 +13,20 @@
         ]
       }
     },
+    "development": {
+      "extends": "base",
+      "developmentClient": true,
+      "distribution": "internal",
+      "environment": "development",
+      "android": {
+        "buildType": "apk",
+        "distribution": "internal"
+      },
+      "ios": {
+        "distribution": "internal",
+        "simulator": true
+      }
+    },
     "preview": {
       "extends": "base",
       "distribution": "internal",

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -42,6 +42,7 @@
     "expo-build-properties": "~56.0.19",
     "expo-calendar": "~56.0.8",
     "expo-constants": "~56.0.18",
+    "expo-dev-client": "~56.0.20",
     "expo-device": "~56.0.4",
     "expo-document-picker": "~56.0.4",
     "expo-file-system": "~56.0.8",

--- a/docs/native-deploy.md
+++ b/docs/native-deploy.md
@@ -1,17 +1,74 @@
 # Native EAS deploy runbook
 
-Manual GitHub Actions deployment for the Expo app in `apps/native` uses EAS Build and, for production builds, EAS Submit.
+GitHub Actions deployment for the Expo app in `apps/native`. Release builds run
+`eas build --local` **on the GitHub runner** (zero EAS Build cloud minutes — see the
+strategy note below), and production builds are shipped with EAS Submit.
+
+## Recommended build strategy
+
+The app is **never** run via Expo Go — it links a custom native module
+(`modules/uoplan-engine`, the Rust schedule engine), so all builds are real native
+builds. The standing approach is **EAS as a credential manager + build orchestrator,
+not a cloud-compute dependency**:
+
+- **Credentials:** EAS manages signing (iOS distribution cert + provisioning profile,
+  Android upload keystore). This is the main reason to keep EAS — it gives reproducible
+  signing locally _and_ in CI with only an `EXPO_TOKEN`, instead of hand-managing
+  fastlane `match`, ASC API keys and keystore custody across machines.
+- **Builds:** `eas build --local` everywhere — locally
+  (`pnpm --filter native eas:build:local`) and in CI (`native-deploy.yml`). Same recipe,
+  reproducible, no cloud minutes. iOS must build on macOS; Android builds anywhere.
+- **Submission:** `eas submit` from a local machine or CI.
 
 ## Current repository state
 
-- Workflow: `.github/workflows/native-deploy.yml`
+- Workflows:
+  - `.github/workflows/native-build-check.yml` — PR/push **build smoke**: a no-signing
+    debug compile of both platforms (Android `assembleDebug` on Linux, iOS simulator
+    build on macOS). Needs no credentials; catches native breakage before release.
+  - `.github/workflows/native-deploy.yml` — release build + store submission.
 - EAS config: `apps/native/eas.json`
 - App IDs:
-  - iOS bundle ID: `party.uoplan.native`
+  - iOS bundle ID: `party.uoplan.app`
   - Android package: `party.uoplan.app`
-- `apps/native/app.json` does **not** have `owner` or `extra.eas.projectId` yet. Create the real EAS project before running CI.
+- `apps/native/app.json` carries the real `owner` (`uoplan`) and
+  `extra.eas.projectId` (`9324474b-4ac4-4f5d-871d-5eebea45fbb6`).
 - Build numbers use `cli.appVersionSource = "remote"` with production `autoIncrement`, so EAS manages iOS build numbers and Android version codes.
-- No EAS `development` build profile is checked in yet because `expo-dev-client` is not installed. Add that dependency before adding a `developmentClient: true` profile.
+- Build profiles in `eas.json`: `development` (`developmentClient: true`, internal
+  distribution, iOS simulator — `expo-dev-client` is installed), `preview` (internal
+  apk / iOS simulator), `production` (store).
+
+## Local development (development build)
+
+`expo-dev-client` is installed, so debug builds are full development builds (custom dev
+menu + launcher, network inspector). Run them on a simulator/emulator with:
+
+```bash
+pnpm --filter native start     # Metro (port 8081)
+pnpm --filter native ios       # expo run:ios     → dev client on the iOS simulator
+pnpm --filter native android   # expo run:android → dev client on an Android emulator
+```
+
+Or produce an installable dev-client build via EAS with no store credentials:
+
+```bash
+eas build --local --profile development --platform android   # dev-client APK
+eas build --local --profile development --platform ios       # iOS simulator dev client
+```
+
+## Local release builds
+
+Same recipe as CI, on your machine (signing pulled from EAS; `eas login` or
+`EXPO_TOKEN` first):
+
+```bash
+pnpm --filter native eas:build:local -- --profile production --platform ios
+pnpm --filter native eas:build:local -- --profile production --platform android
+```
+
+The `eas:build:local` wrapper forces our pnpm-patched local build plugin (drops the
+macOS-Tahoe-breaking `security find-identity -v` flag — see
+`apps/native/scripts/eas-build-local.mts`).
 
 ## One-time setup checklist
 
@@ -49,7 +106,7 @@ Use EAS-managed credentials unless there is a reason to keep local signing files
 
 In Apple Developer / App Store Connect:
 
-- Create the App Store Connect app record for bundle ID `party.uoplan.native`.
+- Create the App Store Connect app record for bundle ID `party.uoplan.app`.
 - Note the numeric App Store Connect app ID (`ascAppId`) from App Information.
 - Create an App Store Connect API key (`.p8`), Key ID, and Issuer ID.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       expo-constants:
         specifier: ~56.0.18
         version: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
+      expo-dev-client:
+        specifier: ~56.0.20
+        version: 56.0.20(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
       expo-device:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.11)
@@ -5892,6 +5895,28 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-dev-client@56.0.20:
+    resolution: {integrity: sha512-KebW4r8HhIiRrPzs6ZqVhp/so8buyglAO1h4No0Ibr5C2XRnlIoGWCN4zC6rW7IsI3iKUXcofLAQV9OjoxjiwQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-launcher@56.0.20:
+    resolution: {integrity: sha512-cTuC3GkPl9CTwO3CKnVmEm9qoQ0WairhwvTh6qMlg+zr/QU/tdiU++uDBX67hf9+FuxQOkWGp5khFNosT+0cIg==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
+  expo-dev-menu-interface@56.0.1:
+    resolution: {integrity: sha512-odATx0ZL/Kis10sKSBiKiGQxAB6coSi/KQtKcMhnQVNno6FkRh5/4e5BqcEvpq2rNMTiQp4ytNAQHtdwbPXvGA==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu@56.0.17:
+    resolution: {integrity: sha512-OofRkOOZnaDriSav3JDN4NP2lsLt2eOa/Ryptr5nMD62SwnFyK4R6n6PkPVaDU3LSsZqndAJHmN6inS+oziayQ==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
   expo-device@56.0.4:
     resolution: {integrity: sha512-ucVcGPkvBrl2QHuy7XcYex2Y6BETvJ6TREutZrwLGUDnlvbpKS8KfQoNZOpvkyo5Nmm9RrasYQ0CrXmBHho2mg==}
     peerDependencies:
@@ -5933,6 +5958,9 @@ packages:
       react-native-web:
         optional: true
 
+  expo-json-utils@56.0.0:
+    resolution: {integrity: sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg==}
+
   expo-keep-awake@56.0.3:
     resolution: {integrity: sha512-CLMJXtEiMKknD3Rpm8CRwE6ZJUzu2yCEmRk1sgfHAJ1zIbuEWY3dpPDubtsnuzWm+2k6Sru+yaFbYsvPWmTiBA==}
     peerDependencies:
@@ -5950,6 +5978,11 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-manifests@56.0.4:
+    resolution: {integrity: sha512-Fokawl2UkiExIF0bqGoblRFA8lYpROVD+EpvDwSW4LgqQyPwNua1gLSgHZjdl5GsVugfRMMWE3LHaibDyX93hw==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@56.0.15:
     resolution: {integrity: sha512-WqpBFwLzn7DsrUkWltIjVmAjwuI1VdQ2jRMlvk1nh2kVadwdJBkSjUBQWRifsEePNhiMT/rFOovBolUU/ARt5w==}
@@ -6042,6 +6075,11 @@ packages:
     peerDependenciesMeta:
       react-native-web:
         optional: true
+
+  expo-updates-interface@56.0.2:
+    resolution: {integrity: sha512-eWTwSZ9y8vrULG2oBn2TQSSIwBGSq/TxGJ3jY6tuVS2FWH/ASRIiKs3zkUZTRoC3ZuV2alz0mUClYV7nNrFx8g==}
+    peerDependencies:
+      expo: '*'
 
   expo-web-browser@56.0.5:
     resolution: {integrity: sha512-kaN+wcR5lHwPCH1IgrU1XyPUQvBRzdF1TMp65uAF9iUCyipqYnmrvV87eqAmrdkFFopWVgU7FcxPu1UZw+gvUQ==}
@@ -16250,6 +16288,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-dev-client@56.0.20(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)):
+    dependencies:
+      expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-dev-launcher: 56.0.20(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
+      expo-dev-menu: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
+      expo-dev-menu-interface: 56.0.1(expo@56.0.11)
+      expo-manifests: 56.0.4(expo@56.0.11)
+      expo-updates-interface: 56.0.2(expo@56.0.11)
+    transitivePeerDependencies:
+      - react-native
+
+  expo-dev-launcher@56.0.20(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)):
+    dependencies:
+      '@expo/schema-utils': 56.0.1
+      expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-dev-menu: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
+      expo-manifests: 56.0.4(expo@56.0.11)
+      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+
+  expo-dev-menu-interface@56.0.1(expo@56.0.11):
+    dependencies:
+      expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+
+  expo-dev-menu@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)):
+    dependencies:
+      expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-dev-menu-interface: 56.0.1(expo@56.0.11)
+      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+
   expo-device@56.0.4(expo@56.0.11):
     dependencies:
       expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -16305,6 +16372,8 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
+  expo-json-utils@56.0.0: {}
+
   expo-keep-awake@56.0.3(expo@56.0.11)(react@19.2.3):
     dependencies:
       expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -16341,6 +16410,11 @@ snapshots:
       expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react: 19.2.3
       rtl-detect: 1.1.2
+
+  expo-manifests@56.0.4(expo@56.0.11):
+    dependencies:
+      expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-json-utils: 56.0.0
 
   expo-modules-autolinking@56.0.15(typescript@5.9.3):
     dependencies:
@@ -16555,6 +16629,10 @@ snapshots:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
+
+  expo-updates-interface@56.0.2(expo@56.0.11):
+    dependencies:
+      expo: 56.0.11(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.10)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
 
   expo-web-browser@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)):
     dependencies:


### PR DESCRIPTION
## What

`apps/native` was never on Expo Go (the custom `modules/uoplan-engine` Rust engine makes it impossible) and already builds release binaries locally via `eas build --local` + `eas submit` in CI. This adds the one genuinely-missing "off Expo Go" piece and tightens the local + CI native workflow:

- **`expo-dev-client@~56.0.20`** + a `development` EAS profile (`developmentClient`, internal, iOS simulator) so dev builds run in a real custom dev client, not Expo Go.
- **`native-build-check.yml`** — PR/push smoke that compiles native (no-signing Android `assembleDebug` on Linux + iOS-simulator `xcodebuild` on macOS, engine built first) on native-affecting changes, so breakage is caught before a release.
- **Docs** — rewrote the stale `create-expo-app` `README.md` and refreshed `docs/native-deploy.md` (correct bundle id `party.uoplan.app`, owner/projectId, EAS-as-credential-manager strategy, dev-client + local-build/submit sections).

## Verification

- `pnpm --filter native exec tsc --noEmit` → 0 errors
- 357 jest tests pass; touched files oxfmt-clean
- Local `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL (debug APK with `libuoplan_engine.so` ×4 ABIs + DevLauncherActivity)

`eas submit` + full production build left for the user (already wired/proven by `native-deploy.yml`).